### PR TITLE
CASMPET-4927: Update cray-service to 5.0.0

### DIFF
--- a/kubernetes/cray-sts/requirements.yaml
+++ b/kubernetes/cray-sts/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: cray-service
-  version: "2.1.0-20201020140814+3e3b3d4"
-  repository: "@cray-internal"
+  version: "5.0.0"
+  repository: "https://artifactory.algol60.net/artifactory/csm-helm-charts"


### PR DESCRIPTION
### Summary and Scope

Updates the cray-service subchart to the latest (5.0.0) for CSM-1.1.

IS THIS A NEW FEATURE OR CRITICAL BUG FIX? N

DOES THIS CHANGE INVOLVE ANY SCHEME CHANGES?  N

REMINDER: HAVE YOU INCREMENTED VERSION NUMBERS? N/A

REMINDER 2: HAVE YOU UPDATED THE COPYRIGHT PER hpe GUIDELINES: Copyright 2014-2021 Hewlett Packard Enterprise Development LP    ? N/A

### Issues and Related PRs

* Resolves CASMPET-4927

### Testing

Tested on:

* Virtual Shasta

Were the install/upgrade based validation checks/tests run?(goss tests/install-validation doc)
Was a fresh Install tested? N   If not, Why? vshasta doesn't install cray-sts for some reason.
Was an Upgrade tested?      Y
Was a Downgrade tested?     Y
If schema changes were part of this change, how were those handled in your upgrade/downgrade testing? N/A

WHAT WAS THE EXTENT OF TESTING PERFORMED? manual
HOW WERE CHANGES VERIFIED TO BE SUCCESSFUL?

Deployed this updated chart. cray-sts didn't even restart, there were no differences.
I fetched a token just to try it.

### Risks and Mitigations

IF APPLICABLE, HAS A SECURITY AUDIT (via SNYK OR OTHERWISE) BEEN RUN? N
ARE THERE KNOWN ISSUES WITH THESE CHANGES? N
ANY OTHER SPECIAL CONSIDERATIONS? N

Requires: None
