### PR TITLE
CASMPET-4934: Bump cray-sts version to prep for release in CSM-1.1

### DIFF
--- a/kubernetes/cray-sts/Chart.yaml
+++ b/kubernetes/cray-sts/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 description: "Kubernetes resources for cray-sts"
 name: "cray-sts"
 home: "cloud/cray-sts"
-version: 0.5.0
+version: 0.6.0


### PR DESCRIPTION
This release includes:

* CASMPET-4927: Update cray-service to 5.0.0

This is the first release of cray-sts for CSM-1.1, the last time
this was released was in 1.0, so the minor version is increased.