### PR TITLE
CASMPET-4941: Change to algol60 chart repository

### DIFF
--- a/kubernetes/cray-sts/requirements.yaml
+++ b/kubernetes/cray-sts/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: cray-service
-  version: "2.1.0-20201020140814+3e3b3d4"
-  repository: "@cray-internal"
+  version: "2.4.0"
+  repository: "https://artifactory.algol60.net/artifactory/csm-helm-charts"


### PR DESCRIPTION
DST's chart repository is going away. The cray-service chart is
being published to algol60 now. I set the version to an old one
that's already in algol60 so that it will build.