### PR TITLE
CASMPET-7062 pick up latest cray-service chart version

### DIFF
--- a/.github/workflows/build_and_release_chart.yaml
+++ b/.github/workflows/build_and_release_chart.yaml
@@ -1,0 +1,9 @@
+name: Build and Publish Helm charts
+on: [push, workflow_dispatch]
+jobs:
+  build_and_release:
+    uses: Cray-HPE/hms-build-chart-workflows/.github/workflows/build_and_release_charts.yaml@v3
+    with:
+      artifactory-component: cray-sts
+      target-branch: main
+    secrets: inherit

--- a/.github/workflows/build_and_release_chart.yaml
+++ b/.github/workflows/build_and_release_chart.yaml
@@ -1,9 +1,0 @@
-name: Build and Publish Helm charts
-on: [push, workflow_dispatch]
-jobs:
-  build_and_release:
-    uses: Cray-HPE/hms-build-chart-workflows/.github/workflows/build_and_release_charts.yaml@v3
-    with:
-      artifactory-component: cray-sts
-      target-branch: main
-    secrets: inherit

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,7 @@ RUN mkdir -p /api
 COPY ./api /api
 
 RUN mkdir -p /install
-COPY --from=base /build/dist/*.whl /install
+COPY --from=build /build/dist/*.whl /install
 RUN pip3 install /install/*.whl
 
 CMD [ "gunicorn", "--bind=0.0.0.0:8000", "--workers=4", "sts.sts:conn_app" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ RUN mkdir -p /build
 COPY . /build
 WORKDIR /build
 
-RUN python setup.py sdist bdist_wheel
+RUN python -m build --sdist --wheel /build
 
 # TODO: uncomment once some tests are created
 # FROM base as test

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,11 @@
 FROM artifactory.algol60.net/docker.io/alpine as base
 
 RUN apk add --no-cache python3 && ln -sf python3 /usr/bin/python
+
+ENV VIRTUAL_ENV=/app/venv
+RUN python3 -m venv $VIRTUAL_ENV
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+
 RUN python3 -m ensurepip
 RUN pip3 install --upgrade pip setuptools wheel gunicorn==20.1.0
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,7 @@ RUN mkdir -p /api
 COPY ./api /api
 
 RUN mkdir -p /install
-COPY --from=build /build/dist/*.whl /install
+COPY --from=base /build/dist/*.whl /install
 RUN pip3 install /install/*.whl
 
 CMD [ "gunicorn", "--bind=0.0.0.0:8000", "--workers=4", "sts.sts:conn_app" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ RUN mkdir -p /build
 COPY . /build
 WORKDIR /build
 
-RUN python3 -m build --sdist --wheel /build
+RUN python -m build --sdist --wheel
 
 # TODO: uncomment once some tests are created
 # FROM base as test

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ RUN mkdir -p /build
 COPY . /build
 WORKDIR /build
 
-RUN python -m build --sdist --wheel
+RUN python -m build --sdist --wheel /build
 
 # TODO: uncomment once some tests are created
 # FROM base as test

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN python3 -m venv $VIRTUAL_ENV
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 
 RUN python3 -m ensurepip
-RUN pip3 install --upgrade pip setuptools wheel gunicorn==20.1.0
+RUN pip3 install --upgrade pip setuptools wheel gunicorn==20.1.0 build
 
 ENV STS_RUNTIME "container"
 ENV STS_ENV "development"

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ RUN mkdir -p /build
 COPY . /build
 WORKDIR /build
 
-RUN python -m build --sdist --wheel /build
+RUN python3 -m build --sdist --wheel /build
 
 # TODO: uncomment once some tests are created
 # FROM base as test

--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ packages/${NAME}-${CHART_VERSION}.tgz:
 
 chart-test:
 	CMD="lint ${CHARTDIR}/${NAME}" $(MAKE) helm
-	docker run --rm -v ${PWD}/${CHARTDIR}:/apps ${HELM_UNITTEST_IMAGE} -3 ${NAME}
+	docker run --rm -v ${PWD}/${CHARTDIR}:/apps ${HELM_UNITTEST_IMAGE} ${NAME}
 
 chart-images: packages/${NAME}-${CHART_VERSION}.tgz
 	{ CMD="template release $< --dry-run --replace --dependency-update" $(MAKE) -s helm; \

--- a/kubernetes/cray-sts/Chart.yaml
+++ b/kubernetes/cray-sts/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: cray-sts
-version: 0.7.1
+version: 0.8.0
 description: Kubernetes resources for cray-sts
 keywords:
   - cray-sts

--- a/kubernetes/cray-sts/Chart.yaml
+++ b/kubernetes/cray-sts/Chart.yaml
@@ -1,13 +1,13 @@
 apiVersion: v2
 name: cray-sts
-version: 0.7.0
+version: 0.7.1
 description: Kubernetes resources for cray-sts
 keywords:
   - cray-sts
 home: https://github.com/Cray-HPE/cray-sts
 dependencies:
   - name: cray-service
-    version: ~7.0.0
+    version: ~10.0.5
     repository: https://artifactory.algol60.net/artifactory/csm-helm-charts/
 maintainers:
   - name: kimjensen-hpe

--- a/kubernetes/cray-sts/values.yaml
+++ b/kubernetes/cray-sts/values.yaml
@@ -78,5 +78,5 @@ cray-service:
 global:
   chart:
     name: cray-sts
-    version: 0.7.0
+    version: 0.8.0
   appVersion: 0.7.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ openapi-schema-validator==0.1.5
 openapi-spec-validator==0.3.1
 pyrsistent==0.18.0
 python-dateutil==2.8.2
-PyYAML==5.4.1
+PyYAML==5.3.1
 requests==2.26.0
 s3transfer==0.5.0
 six==1.16.0


### PR DESCRIPTION
## Summary and Scope

The cray-service chart need to be updated.

I installed this chart on Beau and saw that I was still able to get s3 creds from cray-sts. The following was returned.

```bash
{'Credentials': {'AccessKeyId': 'JtrN...', 'EndpointURL': 'http://rgw-vip.nmn', 'Expiration': '2024-05-24T19:12:20.181702+00:00', 'SecretAccessKey': 'T3G...', 'SessionToken': 'cPv...'}}
```

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

