### PR TITLE
CASMPET-7000 fix builds in cray-sts v0.7.0

### DIFF
--- a/.github/workflows/charts-lint-test-scan.yaml
+++ b/.github/workflows/charts-lint-test-scan.yaml
@@ -4,8 +4,8 @@ on:
     branches:
       - master
       - release/**
-  schedule:
-    - cron: '13 19 * * *'
+  # schedule:
+  #   - cron: '13 19 * * *'
   workflow_dispatch:
 jobs:
   lint-test-scan:
@@ -17,3 +17,6 @@ jobs:
       #scan-image-snyk-args: "--severity-threshold=high"
     secrets:
       snyk-token: ${{ secrets.SNYK_TOKEN }}
+      github-token: ${{ secrets.GITHUB_TOKEN }}
+      artifactory-username: ${{ secrets.ARTIFACTORY_ALGOL60_READONLY_USERNAME }}
+      artifactory-password: ${{ secrets.ARTIFACTORY_ALGOL60_READONLY_TOKEN }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,13 @@
 FROM artifactory.algol60.net/docker.io/alpine as base
 
 RUN apk add --no-cache python3 && ln -sf python3 /usr/bin/python
+
+ENV VIRTUAL_ENV=/app/venv
+RUN python3 -m venv $VIRTUAL_ENV
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+
 RUN python3 -m ensurepip
-RUN pip3 install --upgrade pip setuptools wheel gunicorn==20.1.0
+RUN pip3 install --upgrade pip setuptools wheel gunicorn==20.1.0 build
 
 ENV STS_RUNTIME "container"
 ENV STS_ENV "development"
@@ -16,7 +21,7 @@ RUN mkdir -p /build
 COPY . /build
 WORKDIR /build
 
-RUN python setup.py sdist bdist_wheel
+RUN python -m build --sdist --wheel /build
 
 # TODO: uncomment once some tests are created
 # FROM base as test

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,12 @@ YQ_IMAGE ?= artifactory.algol60.net/docker.io/mikefarah/yq:4
 HELM_IMAGE ?= artifactory.algol60.net/docker.io/alpine/helm:3.7.1
 HELM_UNITTEST_IMAGE ?= artifactory.algol60.net/docker.io/quintush/helm-unittest
 HELM_DOCS_IMAGE ?= artifactory.algol60.net/docker.io/jnorwood/helm-docs:v1.5.0
+ifeq ($(shell uname -s),Darwin)
+	HELM_CONFIG_HOME ?= $(HOME)/Library/Preferences/helm
+else
+	HELM_CONFIG_HOME ?= $(HOME)/.config/helm
+endif
+COMMA := ,
 
 all : image chart
 
@@ -38,9 +44,10 @@ helm:
 	docker run --rm \
 	    --user $(shell id -u):$(shell id -g) \
 	    --mount type=bind,src="$(shell pwd)",dst=/src \
+	    $(if $(wildcard $(HELM_CONFIG_HOME)/.),--mount type=bind$(COMMA)src=$(HELM_CONFIG_HOME)$(COMMA)dst=/tmp/.helm/config) \
 	    -w /src \
 	    -e HELM_CACHE_HOME=/src/.helm/cache \
-	    -e HELM_CONFIG_HOME=/src/.helm/config \
+	    -e HELM_CONFIG_HOME=/tmp/.helm/config \
 	    -e HELM_DATA_HOME=/src/.helm/data \
 	    $(HELM_IMAGE) \
 	    $(CMD)

--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ packages/${NAME}-${CHART_VERSION}.tgz:
 
 chart-test:
 	CMD="lint ${CHARTDIR}/${NAME}" $(MAKE) helm
-	docker run --rm -v ${PWD}/${CHARTDIR}:/apps ${HELM_UNITTEST_IMAGE} -3 ${NAME}
+	docker run --rm -v ${PWD}/${CHARTDIR}:/apps ${HELM_UNITTEST_IMAGE} ${NAME}
 
 chart-images: packages/${NAME}-${CHART_VERSION}.tgz
 	{ CMD="template release $< --dry-run --replace --dependency-update" $(MAKE) -s helm; \

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ openapi-schema-validator==0.1.5
 openapi-spec-validator==0.3.1
 pyrsistent==0.18.0
 python-dateutil==2.8.2
-PyYAML==5.4.1
+PyYAML==5.3.1
 requests==2.26.0
 s3transfer==0.5.0
 six==1.16.0

--- a/testfile
+++ b/testfile
@@ -1,1 +1,0 @@
-this is a test


### PR DESCRIPTION
## Summary and Scope

Image builds were broken in v0.7.0. This PR updates the makefile and jenkinsfile so now the image can be built successfully. There are no changes to the chart or the image in this PR. There are only changes to the build process.


## Risks and Mitigations

Low risk

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

